### PR TITLE
Cleanup for 128bit double support

### DIFF
--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -92,8 +92,7 @@ public:
     hid_t m_H5T_CFLOAT;
     hid_t m_H5T_CDOUBLE;
     hid_t m_H5T_CLONG_DOUBLE;
-    hid_t m_H5T_LONG_DOUBLE_80_BE;
-    hid_t m_H5T_LONG_DOUBLE_80_LE;
+    hid_t m_H5T_LONG_DOUBLE_80;
 
 protected:
 #if openPMD_HAVE_MPI

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -93,6 +93,7 @@ public:
     hid_t m_H5T_CDOUBLE;
     hid_t m_H5T_CLONG_DOUBLE;
     hid_t m_H5T_LONG_DOUBLE_80;
+    hid_t m_H5T_CLONG_DOUBLE_80;
 
 protected:
 #if openPMD_HAVE_MPI

--- a/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
+++ b/include/openPMD/IO/HDF5/HDF5IOHandlerImpl.hpp
@@ -92,6 +92,8 @@ public:
     hid_t m_H5T_CFLOAT;
     hid_t m_H5T_CDOUBLE;
     hid_t m_H5T_CLONG_DOUBLE;
+    hid_t m_H5T_LONG_DOUBLE_80_BE;
+    hid_t m_H5T_LONG_DOUBLE_80_LE;
 
 protected:
 #if openPMD_HAVE_MPI

--- a/include/openPMD/auxiliary/TypeTraits.hpp
+++ b/include/openPMD/auxiliary/TypeTraits.hpp
@@ -77,4 +77,19 @@ namespace
     template <typename>
     inline constexpr bool dependent_false_v = false;
 } // namespace
+
+enum class endian
+{
+    big,
+    little
+};
+
+constexpr endian platform_endianness()
+{
+    // Implementation adapted from the example given here:
+    // https://en.cppreference.com/w/cpp/language/reinterpret_cast
+    int const i = 1;
+    return reinterpret_cast<char const *>(&i)[0] == '\x1' ? endian::little
+                                                          : endian::big;
+}
 } // namespace openPMD::auxiliary

--- a/src/IO/HDF5/HDF5Auxiliary.cpp
+++ b/src/IO/HDF5/HDF5Auxiliary.cpp
@@ -98,7 +98,7 @@ hid_t openPMD::GetH5DataType::operator()(Attribute const &att)
         return H5Tcopy(H5T_NATIVE_DOUBLE);
     case DT::LONG_DOUBLE:
     case DT::VEC_LONG_DOUBLE:
-        return H5Tcopy(H5T_NATIVE_LDOUBLE);
+        return H5Tcopy(m_userTypes.at(typeid(long double).name()));
     case DT::CFLOAT:
     case DT::VEC_CFLOAT:
         return H5Tcopy(m_userTypes.at(typeid(std::complex<float>).name()));

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2216,21 +2216,37 @@ void HDF5IOHandlerImpl::readAttribute(
         }
         else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_BE))
         {
-            // worst case, sizeof(long double) is only 8, so allocate enough memory to fit 16 bytes per member
-            std::vector<long double> vld80be(dims[0]*2, 0);
+            // worst case, sizeof(long double) is only 8, so allocate enough
+            // memory to fit 16 bytes per member
+            std::vector<long double> vld80be(dims[0] * 2, 0);
             status = H5Aread(attr_id, attr_type, vld80be.data());
-            H5Tconvert(attr_type, H5T_NATIVE_LDOUBLE, dims[0],
-                vld80be.data(), nullptr, H5P_DEFAULT);
-            std::cout << attr_name << " size " << dims[0] << ", " << vld80be[0] << " " << vld80be[1] << " " << vld80be[2] << std::endl;
+            H5Tconvert(
+                attr_type,
+                H5T_NATIVE_LDOUBLE,
+                dims[0],
+                vld80be.data(),
+                nullptr,
+                H5P_DEFAULT);
+            std::cout << attr_name << " size " << dims[0] << ", " << vld80be[0]
+                      << " " << vld80be[1] << " " << vld80be[2] << std::endl;
             a = Attribute(vld80be);
         }
         else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
         {
-            // worst case, sizeof(long double) is only 8, so allocate enough memory to fit 16 bytes per member
-            std::vector<long double> vld80le(dims[0]*2, 0);
+            // worst case, sizeof(long double) is only 8, so allocate enough
+            // memory to fit 16 bytes per member
+            std::vector<long double> vld80le(dims[0] * 2, 0);
             status = H5Aread(attr_id, attr_type, vld80le.data());
-            H5Tconvert(attr_type, H5T_NATIVE_LDOUBLE, dims[0], vld80le.data(), nullptr, H5P_DEFAULT);
-            std::cout << attr_name << sizeof(long double) <<  " size " << dims[0] << ", " << vld80le[0] << " " << vld80le[1] << " " << vld80le[2] << std::endl;
+            H5Tconvert(
+                attr_type,
+                H5T_NATIVE_LDOUBLE,
+                dims[0],
+                vld80le.data(),
+                nullptr,
+                H5P_DEFAULT);
+            std::cout << attr_name << sizeof(long double) << " size " << dims[0]
+                      << ", " << vld80le[0] << " " << vld80le[1] << " "
+                      << vld80le[2] << std::endl;
             a = Attribute(vld80le);
         }
         else if (H5Tget_class(attr_type) == H5T_STRING)
@@ -2281,12 +2297,15 @@ void HDF5IOHandlerImpl::readAttribute(
 
             std::cout << "order " << std::to_string(order) << std::endl
                       << "prec " << std::to_string(prec) << std::endl
-                << "ebias " << std::to_string(ebias) << std::endl
-                      << "fields " << std::to_string(spos) << " " << std::to_string(epos) << " " << std::to_string(esize) << " " << std::to_string(mpos) << " " << std::to_string(msize)
-                      << "norm " << std::to_string(norm) << std::endl
+                      << "ebias " << std::to_string(ebias) << std::endl
+                      << "fields " << std::to_string(spos) << " "
+                      << std::to_string(epos) << " " << std::to_string(esize)
+                      << " " << std::to_string(mpos) << " "
+                      << std::to_string(msize) << "norm "
+                      << std::to_string(norm) << std::endl
                       << "cset " << std::to_string(cset) << std::endl
                       << "sign " << std::to_string(sign) << std::endl
-                << std::endl;
+                      << std::endl;
 
             throw error::ReadError(
                 error::AffectedObject::Attribute,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -73,6 +73,8 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
     , m_H5T_CFLOAT{H5Tcreate(H5T_COMPOUND, sizeof(float) * 2)}
     , m_H5T_CDOUBLE{H5Tcreate(H5T_COMPOUND, sizeof(double) * 2)}
     , m_H5T_CLONG_DOUBLE{H5Tcreate(H5T_COMPOUND, sizeof(long double) * 2)}
+    , m_H5T_LONG_DOUBLE_80_BE{H5Tcopy(H5T_IEEE_F64BE)}
+    , m_H5T_LONG_DOUBLE_80_LE{H5Tcopy(H5T_IEEE_F64LE)}
 {
     // create a h5py compatible bool type
     VERIFY(
@@ -106,6 +108,28 @@ HDF5IOHandlerImpl::HDF5IOHandlerImpl(
     H5Tinsert(m_H5T_CDOUBLE, "i", sizeof(double), H5T_NATIVE_DOUBLE);
     H5Tinsert(m_H5T_CLONG_DOUBLE, "r", 0, H5T_NATIVE_LDOUBLE);
     H5Tinsert(m_H5T_CLONG_DOUBLE, "i", sizeof(long double), H5T_NATIVE_LDOUBLE);
+
+    H5Tset_size(m_H5T_LONG_DOUBLE_80_BE, 16);
+    H5Tset_order(m_H5T_LONG_DOUBLE_80_BE, H5T_ORDER_BE);
+    H5Tset_precision(m_H5T_LONG_DOUBLE_80_BE, 80);
+    H5Tset_fields(m_H5T_LONG_DOUBLE_80_BE, 79, 64, 15, 0, 64);
+    H5Tset_ebias(m_H5T_LONG_DOUBLE_80_BE, 16383);
+    H5Tset_norm(m_H5T_LONG_DOUBLE_80_BE, H5T_NORM_NONE);
+
+    H5Tset_size(m_H5T_LONG_DOUBLE_80_LE, 16);
+    H5Tset_order(m_H5T_LONG_DOUBLE_80_LE, H5T_ORDER_LE);
+    H5Tset_precision(m_H5T_LONG_DOUBLE_80_LE, 80);
+    H5Tset_fields(m_H5T_LONG_DOUBLE_80_LE, 79, 64, 15, 0, 64);
+    H5Tset_ebias(m_H5T_LONG_DOUBLE_80_LE, 16383);
+    H5Tset_norm(m_H5T_LONG_DOUBLE_80_LE, H5T_NORM_NONE);
+
+    VERIFY(
+        m_H5T_LONG_DOUBLE_80_BE >= 0,
+        "[HDF5] Internal error: Failed to create 128-bit long double BE");
+
+    VERIFY(
+        m_H5T_LONG_DOUBLE_80_LE >= 0,
+        "[HDF5] Internal error: Failed to create 128-bit long double LE");
 
     m_chunks = auxiliary::getEnvString("OPENPMD_HDF5_CHUNKS", "auto");
     // JSON option can overwrite env option:
@@ -2184,6 +2208,31 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, vcld.data());
             a = Attribute(vcld);
         }
+        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE))
+        {
+            std::vector<std::complex<long double> > vcld(dims[0], 0);
+            status = H5Aread(attr_id, attr_type, vcld.data());
+            a = Attribute(vcld);
+        }
+        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_BE))
+        {
+            // worst case, sizeof(long double) is only 8, so allocate enough memory to fit 16 bytes per member
+            std::vector<long double> vld80be(dims[0]*2, 0);
+            status = H5Aread(attr_id, attr_type, vld80be.data());
+            H5Tconvert(attr_type, H5T_NATIVE_LDOUBLE, dims[0],
+                vld80be.data(), nullptr, H5P_DEFAULT);
+            std::cout << attr_name << " size " << dims[0] << ", " << vld80be[0] << " " << vld80be[1] << " " << vld80be[2] << std::endl;
+            a = Attribute(vld80be);
+        }
+        else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
+        {
+            // worst case, sizeof(long double) is only 8, so allocate enough memory to fit 16 bytes per member
+            std::vector<long double> vld80le(dims[0]*2, 0);
+            status = H5Aread(attr_id, attr_type, vld80le.data());
+            H5Tconvert(attr_type, H5T_NATIVE_LDOUBLE, dims[0], vld80le.data(), nullptr, H5P_DEFAULT);
+            std::cout << attr_name << sizeof(long double) <<  " size " << dims[0] << ", " << vld80le[0] << " " << vld80le[1] << " " << vld80le[2] << std::endl;
+            a = Attribute(vld80le);
+        }
         else if (H5Tget_class(attr_type) == H5T_STRING)
         {
             std::vector<std::string> vs;
@@ -2218,11 +2267,34 @@ void HDF5IOHandlerImpl::readAttribute(
             a = Attribute(vs);
         }
         else
+        {
+            auto order = H5Tget_order(attr_type);
+            auto size = H5Tget_size(attr_type);
+            auto prec = H5Tget_precision(attr_type);
+            auto ebias = H5Tget_ebias(attr_type);
+            size_t spos, epos, esize, mpos, msize;
+            H5Tget_fields(attr_type, &spos, &epos, &esize, &mpos, &msize);
+
+            auto norm = H5Tget_norm(attr_type);
+            auto cset = H5Tget_cset(attr_type);
+            auto sign = H5Tget_sign(attr_type);
+
+            std::cout << "order " << std::to_string(order) << std::endl
+                      << "prec " << std::to_string(prec) << std::endl
+                << "ebias " << std::to_string(ebias) << std::endl
+                      << "fields " << std::to_string(spos) << " " << std::to_string(epos) << " " << std::to_string(esize) << " " << std::to_string(mpos) << " " << std::to_string(msize)
+                      << "norm " << std::to_string(norm) << std::endl
+                      << "cset " << std::to_string(cset) << std::endl
+                      << "sign " << std::to_string(sign) << std::endl
+                << std::endl;
+
             throw error::ReadError(
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 "HDF5",
-                "[HDF5] Unsupported simple attribute type");
+                "[HDF5] Unsupported simple attribute type " +
+                    std::to_string(attr_type) + " for " + attr_name);
+        }
     }
     else
         throw std::runtime_error("[HDF5] Unsupported attribute class");

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -612,8 +612,8 @@ void HDF5IOHandlerImpl::createDataset(
              {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
              {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
              {typeid(long double).name(),
-              sizeof(long double) == 8 ? m_H5T_LONG_DOUBLE_80
-                                       : H5T_NATIVE_LDOUBLE}});
+              sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
+                                        : H5T_NATIVE_LDOUBLE}});
         hid_t datatype = getH5DataType(a);
         VERIFY(
             datatype >= 0,
@@ -1312,8 +1312,8 @@ void HDF5IOHandlerImpl::writeDataset(
          {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
          {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
          {typeid(long double).name(),
-          sizeof(long double) == 8 ? m_H5T_LONG_DOUBLE_80
-                                   : H5T_NATIVE_LDOUBLE}});
+          sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
+                                    : H5T_NATIVE_LDOUBLE}});
 
     // TODO Check if parameter dtype and dataset dtype match
     Attribute a(0);
@@ -1425,8 +1425,8 @@ void HDF5IOHandlerImpl::writeAttribute(
          {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
          {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
          {typeid(long double).name(),
-          sizeof(long double) == 8 ? m_H5T_LONG_DOUBLE_80
-                                   : H5T_NATIVE_LDOUBLE}});
+          sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
+                                    : H5T_NATIVE_LDOUBLE}});
     hid_t dataType = getH5DataType(att);
     VERIFY(
         dataType >= 0,
@@ -1774,8 +1774,8 @@ void HDF5IOHandlerImpl::readDataset(
          {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
          {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
          {typeid(long double).name(),
-          sizeof(long double) == 8 ? m_H5T_LONG_DOUBLE_80
-                                   : H5T_NATIVE_LDOUBLE}});
+          sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
+                                    : H5T_NATIVE_LDOUBLE}});
     hid_t dataType = getH5DataType(a);
     VERIFY(
         dataType >= 0,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -622,12 +622,8 @@ void HDF5IOHandlerImpl::createDataset(
             {{typeid(bool).name(), m_H5T_BOOL_ENUM},
              {typeid(std::complex<float>).name(), m_H5T_CFLOAT},
              {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
-             {typeid(std::complex<long double>).name(),
-              sizeof(long double) == 16 ? m_H5T_CLONG_DOUBLE_80
-                                        : m_H5T_CLONG_DOUBLE},
-             {typeid(long double).name(),
-              sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
-                                        : H5T_NATIVE_LDOUBLE}});
+             {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
+             {typeid(long double).name(), H5T_NATIVE_LDOUBLE}});
         hid_t datatype = getH5DataType(a);
         VERIFY(
             datatype >= 0,
@@ -1326,12 +1322,8 @@ void HDF5IOHandlerImpl::writeDataset(
         {{typeid(bool).name(), m_H5T_BOOL_ENUM},
          {typeid(std::complex<float>).name(), m_H5T_CFLOAT},
          {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
-         {typeid(std::complex<long double>).name(),
-          sizeof(long double) == 16 ? m_H5T_CLONG_DOUBLE_80
-                                    : m_H5T_CLONG_DOUBLE},
-         {typeid(long double).name(),
-          sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
-                                    : H5T_NATIVE_LDOUBLE}});
+         {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
+         {typeid(long double).name(), H5T_NATIVE_LDOUBLE}});
 
     // TODO Check if parameter dtype and dataset dtype match
     Attribute a(0);
@@ -1441,12 +1433,8 @@ void HDF5IOHandlerImpl::writeAttribute(
         {{typeid(bool).name(), m_H5T_BOOL_ENUM},
          {typeid(std::complex<float>).name(), m_H5T_CFLOAT},
          {typeid(std::complex<double>).name(), m_H5T_CDOUBLE},
-         {typeid(std::complex<long double>).name(),
-          sizeof(long double) == 16 ? m_H5T_CLONG_DOUBLE_80
-                                    : m_H5T_CLONG_DOUBLE},
-         {typeid(long double).name(),
-          sizeof(long double) == 16 ? m_H5T_LONG_DOUBLE_80
-                                    : H5T_NATIVE_LDOUBLE}});
+         {typeid(std::complex<long double>).name(), m_H5T_CLONG_DOUBLE},
+         {typeid(long double).name(), H5T_NATIVE_LDOUBLE}});
     hid_t dataType = getH5DataType(att);
     VERIFY(
         dataType >= 0,

--- a/src/IO/HDF5/HDF5IOHandler.cpp
+++ b/src/IO/HDF5/HDF5IOHandler.cpp
@@ -2208,12 +2208,6 @@ void HDF5IOHandlerImpl::readAttribute(
             status = H5Aread(attr_id, attr_type, vcld.data());
             a = Attribute(vcld);
         }
-        else if (H5Tequal(attr_type, m_H5T_CLONG_DOUBLE))
-        {
-            std::vector<std::complex<long double> > vcld(dims[0], 0);
-            status = H5Aread(attr_id, attr_type, vcld.data());
-            a = Attribute(vcld);
-        }
         else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_BE))
         {
             // worst case, sizeof(long double) is only 8, so allocate enough
@@ -2227,8 +2221,6 @@ void HDF5IOHandlerImpl::readAttribute(
                 vld80be.data(),
                 nullptr,
                 H5P_DEFAULT);
-            std::cout << attr_name << " size " << dims[0] << ", " << vld80be[0]
-                      << " " << vld80be[1] << " " << vld80be[2] << std::endl;
             a = Attribute(vld80be);
         }
         else if (H5Tequal(attr_type, m_H5T_LONG_DOUBLE_80_LE))
@@ -2244,9 +2236,6 @@ void HDF5IOHandlerImpl::readAttribute(
                 vld80le.data(),
                 nullptr,
                 H5P_DEFAULT);
-            std::cout << attr_name << sizeof(long double) << " size " << dims[0]
-                      << ", " << vld80le[0] << " " << vld80le[1] << " "
-                      << vld80le[2] << std::endl;
             a = Attribute(vld80le);
         }
         else if (H5Tget_class(attr_type) == H5T_STRING)
@@ -2285,7 +2274,6 @@ void HDF5IOHandlerImpl::readAttribute(
         else
         {
             auto order = H5Tget_order(attr_type);
-            auto size = H5Tget_size(attr_type);
             auto prec = H5Tget_precision(attr_type);
             auto ebias = H5Tget_ebias(attr_type);
             size_t spos, epos, esize, mpos, msize;
@@ -2295,24 +2283,27 @@ void HDF5IOHandlerImpl::readAttribute(
             auto cset = H5Tget_cset(attr_type);
             auto sign = H5Tget_sign(attr_type);
 
-            std::cout << "order " << std::to_string(order) << std::endl
-                      << "prec " << std::to_string(prec) << std::endl
-                      << "ebias " << std::to_string(ebias) << std::endl
-                      << "fields " << std::to_string(spos) << " "
-                      << std::to_string(epos) << " " << std::to_string(esize)
-                      << " " << std::to_string(mpos) << " "
-                      << std::to_string(msize) << "norm "
-                      << std::to_string(norm) << std::endl
-                      << "cset " << std::to_string(cset) << std::endl
-                      << "sign " << std::to_string(sign) << std::endl
-                      << std::endl;
+            std::stringstream detailed_info;
+            detailed_info << "order " << std::to_string(order) << std::endl
+                          << "prec " << std::to_string(prec) << std::endl
+                          << "ebias " << std::to_string(ebias) << std::endl
+                          << "fields " << std::to_string(spos) << " "
+                          << std::to_string(epos) << " "
+                          << std::to_string(esize) << " "
+                          << std::to_string(mpos) << " "
+                          << std::to_string(msize) << "norm "
+                          << std::to_string(norm) << std::endl
+                          << "cset " << std::to_string(cset) << std::endl
+                          << "sign " << std::to_string(sign) << std::endl
+                          << std::endl;
 
             throw error::ReadError(
                 error::AffectedObject::Attribute,
                 error::Reason::UnexpectedContent,
                 "HDF5",
                 "[HDF5] Unsupported simple attribute type " +
-                    std::to_string(attr_type) + " for " + attr_name);
+                    std::to_string(attr_type) + " for " + attr_name +
+                    ".\n(Info for debugging: " + detailed_info.str() + ")");
         }
     }
     else


### PR DESCRIPTION
This

* removes debugging output
* unifies `m_H5T_LONG_DOUBLE_80_BE` and `m_H5T_LONG_DOUBLE_80_LE` into a shared datatype whose endianness is determined by the platform (is this the correct way to do it or should we stick with both versions???)
* applies `m_H5T_LONG_DOUBLE_80` where applicable

Todo:
- [ ] Support for `std::complex<long double>`
- [ ] Add a test based on the openPMD example datasets